### PR TITLE
Make a Godot 4 supported version of the library

### DIFF
--- a/CustomInputEvents/InputEventMultiScreenDrag.gd
+++ b/CustomInputEvents/InputEventMultiScreenDrag.gd
@@ -13,5 +13,5 @@ func _init(_raw_gesture : RawGesture = null, event : InputEventScreenDrag = null
 		position = raw_gesture.centroid("drags", "position")
 		relative = event.relative/fingers 
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|relative=" + str(relative) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventMultiScreenLongPress.gd
+++ b/CustomInputEvents/InputEventMultiScreenLongPress.gd
@@ -11,5 +11,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		fingers = raw_gesture.size()
 		position = raw_gesture.centroid("presses", "position")
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventMultiScreenSwipe.gd
+++ b/CustomInputEvents/InputEventMultiScreenSwipe.gd
@@ -13,5 +13,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		position = raw_gesture.centroid("presses", "position")
 		relative = raw_gesture.centroid("releases", "position") - position
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|relative=" + str(relative) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventMultiScreenTap.gd
+++ b/CustomInputEvents/InputEventMultiScreenTap.gd
@@ -11,5 +11,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		fingers = raw_gesture.size()
 		position = raw_gesture.centroid("presses", "position")
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventScreenCancel.gd
+++ b/CustomInputEvents/InputEventScreenCancel.gd
@@ -1,0 +1,12 @@
+class_name InputEventScreenCancel
+extends InputEventAction
+
+var raw_gesture : RawGesture
+var event       : InputEvent
+
+func _init(_raw_gesture : RawGesture, _event : InputEvent) -> void:
+	raw_gesture = _raw_gesture
+	event       = _event
+
+func as_string() -> String:
+	return "gesture canceled"

--- a/CustomInputEvents/InputEventScreenPinch.gd
+++ b/CustomInputEvents/InputEventScreenPinch.gd
@@ -22,5 +22,5 @@ func _init(_raw_gesture : RawGesture = null, event : InputEventScreenDrag = null
 		relative = ((centroid_relative_position + event.relative).length() - centroid_relative_position.length())
 
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|relative=" + str(relative) +"|distance ="+str(distance) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventScreenTwist.gd
+++ b/CustomInputEvents/InputEventScreenTwist.gd
@@ -15,5 +15,5 @@ func _init(_raw_gesture : RawGesture = null, event : InputEventScreenDrag = null
 		var centroid_relative_position = event.position - position
 		relative = centroid_relative_position.angle_to(centroid_relative_position + event.relative)/fingers
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|relative=" + str(relative) + "|fingers=" + str(fingers)

--- a/CustomInputEvents/InputEventSingleScreenDrag.gd
+++ b/CustomInputEvents/InputEventSingleScreenDrag.gd
@@ -12,5 +12,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		position = dragEvent.position
 		relative = dragEvent.relative
 
-func as_text():
+func as_string():
 	return "position=" + str(position) + "|relative=" + str(relative)

--- a/CustomInputEvents/InputEventSingleScreenLongPress.gd
+++ b/CustomInputEvents/InputEventSingleScreenLongPress.gd
@@ -24,5 +24,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		position = raw_gesture.presses.values()[0].position
 
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position)

--- a/CustomInputEvents/InputEventSingleScreenLongPress.gd
+++ b/CustomInputEvents/InputEventSingleScreenLongPress.gd
@@ -24,7 +24,7 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 			var error_msg="Hello! we are trying to fix this bug.\nTo help us please copy the output and comment it (attached as a file) in the following issue: https://github.com/Federico-Ciuffardi/GodotTouchInputManager/issues/20\nAlso, if you can, include in that comment what version of Godot you are using, what platform you are running on, and what you were doing when the error occurred.\nThanks!"
 			print(error_msg)
 			
-			assert(false,error_msg_short)
+			assert(false, error_msg_short)
 		position = raw_gesture.presses[0].position
 
 

--- a/CustomInputEvents/InputEventSingleScreenSwipe.gd
+++ b/CustomInputEvents/InputEventSingleScreenSwipe.gd
@@ -12,5 +12,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		relative = raw_gesture.releases[0].position - position
 
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|relative=" + str(relative)

--- a/CustomInputEvents/InputEventSingleScreenTap.gd
+++ b/CustomInputEvents/InputEventSingleScreenTap.gd
@@ -10,5 +10,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 		position = raw_gesture.presses.values()[0].position
 
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position)

--- a/CustomInputEvents/InputEventSingleScreenTouch.gd
+++ b/CustomInputEvents/InputEventSingleScreenTouch.gd
@@ -2,18 +2,18 @@ class_name InputEventSingleScreenTouch
 extends InputEventAction
 
 var position   : Vector2
-var cancelled  : bool
+var canceled  : bool
 var raw_gesture : RawGesture
 
 func _init(_raw_gesture : RawGesture = null) -> void:
 	raw_gesture = _raw_gesture
 	if raw_gesture:
-		pressed = raw_gesture.releases.empty()
+		pressed = raw_gesture.releases.is_empty()
 		if pressed:
 			position = raw_gesture.presses.values()[0].position
 		else:
 			position = raw_gesture.releases.values()[0].position
-		cancelled = raw_gesture.size() > 1
+		canceled = raw_gesture.size() > 1
 
 func as_text() -> String:
-	return "position=" + str(position) + "|pressed=" + str(pressed) + "|cancelled=" + str(cancelled)
+	return "position=" + str(position) + "|pressed=" + str(pressed) + "|canceled=" + str(canceled)

--- a/CustomInputEvents/InputEventSingleScreenTouch.gd
+++ b/CustomInputEvents/InputEventSingleScreenTouch.gd
@@ -15,5 +15,5 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 			position = raw_gesture.releases.values()[0].position
 		canceled = raw_gesture.size() > 1
 
-func as_text() -> String:
+func as_string() -> String:
 	return "position=" + str(position) + "|pressed=" + str(pressed) + "|canceled=" + str(canceled)

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -63,6 +63,7 @@ signal multi_long_press
 signal pinch
 signal twist
 signal raw_gesture
+signal cancel
 signal any_gesture
 
 ########
@@ -154,6 +155,10 @@ func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 		_emit("twist", twist_event)
 
 func _handle_screen_touch(event : InputEventScreenTouch) -> void:
+	if event.index < 0:
+		_emit("cancel", InputEventScreenCancel.new(raw_gesture_data, event))
+		_end_gesture()
+		return
 
 	# ignore orphaned touch release events
 	if !event.pressed and not event.index in raw_gesture_data.presses:
@@ -196,6 +201,11 @@ func _handle_screen_touch(event : InputEventScreenTouch) -> void:
 		_cancel_single_drag()
 
 func _handle_screen_drag(event : InputEventScreenDrag) -> void:
+	if event.index < 0:
+		_emit("cancel", InputEventScreenCancel.new(raw_gesture_data, event))
+		_end_gesture()
+		return
+
 	raw_gesture_data._update_screen_drag(event)
 	_emit("raw_gesture", raw_gesture_data)
 	if raw_gesture_data.drags.size() > 1:

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -135,12 +135,12 @@ func _unhandled_input(event : InputEvent) -> void:
 		
 func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 	if raw_gesture_data.size() == 1 and _mouse_event == Gesture.SINGLE_DRAG:
-		_emit("drag", _native_drag_event(0, event.position, event.relative, event.speed))
+		_emit("drag", _native_drag_event(0, event.position, event.relative, event.velocity))
 	elif raw_gesture_data.size() == 2 and _mouse_event == Gesture.MULTI_DRAG:
 		var offset = Vector2(5,5)
-		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.speed)
+		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.velocity)
 		raw_gesture_data._update_screen_drag(e0)
-		var e1 = _native_drag_event(1, event.position+offset, event.relative, event.speed)
+		var e1 = _native_drag_event(1, event.position+offset, event.relative, event.velocity)
 		raw_gesture_data._update_screen_drag(e1)
 		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e0))
 		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e1))

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -135,7 +135,7 @@ func _unhandled_input(event : InputEvent) -> void:
 		
 func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 	if _mouse_event == Gesture.SINGLE_DRAG:
-	  _emit("drag", _native_drag_event(0, event.position, event.relative, event.velocity))
+		_emit("drag", _native_drag_event(0, event.position, event.relative, event.velocity))
 	elif _mouse_event == Gesture.MULTI_DRAG:
 		var offset = Vector2(5,5)
 		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.velocity)
@@ -185,12 +185,12 @@ func _handle_screen_touch(event : InputEventScreenTouch) -> void:
 			if _single_touch_cancelled:
 				var distance : float = (raw_gesture_data.centroid("releases","position") - raw_gesture_data.centroid("presses","position")).length()
 				if raw_gesture_data.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT and\
-					 raw_gesture_data.is_consistent(TAP_DISTANCE_LIMIT, FINGER_SIZE*fingers) and\
-					 _released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
+					raw_gesture_data.is_consistent(TAP_DISTANCE_LIMIT, FINGER_SIZE*fingers) and\
+					_released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
 					_emit("multi_tap", InputEventMultiScreenTap.new(raw_gesture_data))
 				if raw_gesture_data.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD and\
-					 raw_gesture_data.is_consistent(FINGER_SIZE, FINGER_SIZE*fingers) and\
-					 _released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
+					raw_gesture_data.is_consistent(FINGER_SIZE, FINGER_SIZE*fingers) and\
+					_released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
 					_emit("multi_swipe", InputEventMultiScreenSwipe.new(raw_gesture_data))
 			_end_gesture()
 		_cancel_single_drag()
@@ -315,8 +315,8 @@ func _on_long_press_timer_timeout() -> void:
 	var starts_centroid : Vector2    = raw_gesture_data.centroid("presses", "position")
 	var distance        : float      = (ends_centroid - starts_centroid).length()
 
-	if raw_gesture_data.releases.empty() and distance <= LONG_PRESS_DISTANCE_LIMIT and\
-		 raw_gesture_data.is_consistent(LONG_PRESS_DISTANCE_LIMIT, FINGER_SIZE*raw_gesture_data.size()):
+	if raw_gesture_data.releases.is_empty() and distance <= LONG_PRESS_DISTANCE_LIMIT and\
+		raw_gesture_data.is_consistent(LONG_PRESS_DISTANCE_LIMIT, FINGER_SIZE*raw_gesture_data.size()):
 		if _single_touch_cancelled:
 			_emit("multi_long_press", InputEventMultiScreenLongPress.new(raw_gesture_data))
 		else:
@@ -352,7 +352,7 @@ func _native_mouse_button_event(button : int) -> InputEventMouseButton:
 
 func _native_key_event(key : int) -> InputEventKey:
 	var ev = InputEventKey.new()
-	ev.scancode = key
+	ev.keycode = key
 	return ev
 
 func _set_default_action(action : String, event : InputEvent) -> void:

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -134,16 +134,16 @@ func _unhandled_input(event : InputEvent) -> void:
 		_handle_action(event)
 		
 func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
-	if raw_gesture.size() == 1 and _mouse_event == Gesture.SINGLE_DRAG:
-	  _emit("drag", _native_drag_event(0, event.position, event.relative, event.speed))
-	elif raw_gesture.size() == 2 and _mouse_event == Gesture.MULTI_DRAG:
-			var offset = Vector2(5,5)
-			var e0 = _native_drag_event(0, event.position-offset, event.relative, event.speed)
-			raw_gesture._update_screen_drag(e0)
-			var e1 = _native_drag_event(1, event.position+offset, event.relative, event.speed)
-			raw_gesture._update_screen_drag(e1)
-			_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture,e0))
-			_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture,e1))
+	if raw_gesture_data.size() == 1 and _mouse_event == Gesture.SINGLE_DRAG:
+		_emit("drag", _native_drag_event(0, event.position, event.relative, event.speed))
+	elif raw_gesture_data.size() == 2 and _mouse_event == Gesture.MULTI_DRAG:
+		var offset = Vector2(5,5)
+		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.speed)
+		raw_gesture_data._update_screen_drag(e0)
+		var e1 = _native_drag_event(1, event.position+offset, event.relative, event.speed)
+		raw_gesture_data._update_screen_drag(e1)
+		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e0))
+		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e1))
 	elif _mouse_event == Gesture.TWIST:
 		var rel1 = event.position - _mouse_event_press_position
 		var rel2 = rel1 + event.relative

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -30,7 +30,7 @@ const SWIPE_DISTANCE_THRESHOLD : float = 200.0
 # CONST #
 #########
 
-const Util : Object = preload("Util.gd")
+const Util : GDScript = preload("Util.gd")
 
 const	swipe2dir : Dictionary = \
 {
@@ -75,7 +75,7 @@ enum Gesture {PINCH, MULTI_DRAG, TWIST, SINGLE_DRAG, NONE}
 # Vars #
 ########
 
-var raw_gesture : RawGesture = RawGesture.new() # Current raw_gesture
+var raw_gesture_data : RawGesture = RawGesture.new() # Current raw_gesture
 
 var _mouse_event_press_position : Vector2
 var _mouse_event : int = Gesture.NONE
@@ -114,14 +114,14 @@ func _ready() -> void:
 		_set_default_action("single_swipe_left"      , _native_key_event(KEY_A))
 		_set_default_action("single_swipe_up_left"   , _native_key_event(KEY_Q))
 
-		# _set_default_action("single_touch"           , _native_mouse_button_event(BUTTON_LEFT))
-		_set_default_action("multi_touch"              , _native_mouse_button_event(BUTTON_MIDDLE))
-		# _set_default_action("pinch"                  , _native_mouse_button_event(BUTTON_RIGHT)) # TODO
-		_set_default_action("pinch_outward"            , _native_mouse_button_event(BUTTON_WHEEL_UP))
-		_set_default_action("pinch_inward"             , _native_mouse_button_event(BUTTON_WHEEL_DOWN))
-		_set_default_action("twist"                    , _native_mouse_button_event(BUTTON_RIGHT))
-		# _set_default_action("twist_clockwise"        , _native_mouse_button_event(BUTTON_WHEEL_UP)) # TODO
-		# _set_default_action("twist_counterclockwise" , _native_mouse_button_event(BUTTON_WHEEL_DOWN)) # TODO
+		# _set_default_action("single_touch"           , _native_mouse_button_event(MOUSE_BUTTON_LEFT))
+		_set_default_action("multi_touch"              , _native_mouse_button_event(MOUSE_BUTTON_MIDDLE))
+		# _set_default_action("pinch"                  , _native_mouse_button_event(MOUSE_BUTTON_RIGHT)) # TODO
+		_set_default_action("pinch_outward"            , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_UP))
+		_set_default_action("pinch_inward"             , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_DOWN))
+		_set_default_action("twist"                    , _native_mouse_button_event(MOUSE_BUTTON_RIGHT))
+		# _set_default_action("twist_clockwise"        , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_UP)) # TODO
+		# _set_default_action("twist_counterclockwise" , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_DOWN)) # TODO
 
 func _unhandled_input(event : InputEvent) -> void:
 	if event is InputEventScreenDrag:
@@ -135,15 +135,15 @@ func _unhandled_input(event : InputEvent) -> void:
 		
 func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 	if _mouse_event == Gesture.SINGLE_DRAG:
-	  _emit("drag", _native_drag_event(0, event.position, event.relative, event.speed))
+	  _emit("drag", _native_drag_event(0, event.position, event.relative, event.velocity))
 	elif _mouse_event == Gesture.MULTI_DRAG:
 		var offset = Vector2(5,5)
-		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.speed)
-		raw_gesture._update_screen_drag(e0)
-		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture,e0))
-		var e1 = _native_drag_event(1, event.position+offset, event.relative, event.speed)
-		raw_gesture._update_screen_drag(e1)
-		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture,e1))
+		var e0 = _native_drag_event(0, event.position-offset, event.relative, event.velocity)
+		raw_gesture_data._update_screen_drag(e0)
+		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e0))
+		var e1 = _native_drag_event(1, event.position+offset, event.relative, event.velocity)
+		raw_gesture_data._update_screen_drag(e1)
+		_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data,e1))
 	elif _mouse_event == Gesture.TWIST:
 		var rel1 = event.position - _mouse_event_press_position
 		var rel2 = rel1 + event.relative
@@ -156,60 +156,60 @@ func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 func _handle_screen_touch(event : InputEventScreenTouch) -> void:
 
 	# ignore orphaned touch release events
-	if !event.pressed and not event.index in raw_gesture.presses:
+	if !event.pressed and not event.index in raw_gesture_data.presses:
 		return
 
-	raw_gesture._update_screen_touch(event)
-	_emit("raw_gesture", raw_gesture)
+	raw_gesture_data._update_screen_touch(event)
+	_emit("raw_gesture", raw_gesture_data)
 	var index : int = event.index
 	if event.pressed:
-		if raw_gesture.size() == 1: # First and only touch
+		if raw_gesture_data.size() == 1: # First and only touch
 			_long_press_timer.start(LONG_PRESS_TIME_THRESHOLD)
 			_single_touch_cancelled = false
-			_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture))
+			_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture_data))
 		elif !_single_touch_cancelled :
 				_single_touch_cancelled = true
 				_cancel_single_drag()
-				_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture))
+				_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture_data))
 	else:
-		var fingers : int = raw_gesture.size() 
+		var fingers : int = raw_gesture_data.size() 
 		if index == 0:
-			_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture))
+			_emit("single_touch", InputEventSingleScreenTouch.new(raw_gesture_data))
 			if !_single_touch_cancelled:
-				var distance : float = (raw_gesture.releases[0].position - raw_gesture.presses[0].position).length()
-				if raw_gesture.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT:
-					_emit("single_tap", InputEventSingleScreenTap.new(raw_gesture))
-				if raw_gesture.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD:
-					_emit("single_swipe", InputEventSingleScreenSwipe.new(raw_gesture))
-		if raw_gesture.active_touches == 0: # last finger released
+				var distance : float = (raw_gesture_data.releases[0].position - raw_gesture_data.presses[0].position).length()
+				if raw_gesture_data.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT:
+					_emit("single_tap", InputEventSingleScreenTap.new(raw_gesture_data))
+				if raw_gesture_data.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD:
+					_emit("single_swipe", InputEventSingleScreenSwipe.new(raw_gesture_data))
+		if raw_gesture_data.active_touches == 0: # last finger released
 			if _single_touch_cancelled:
-				var distance : float = (raw_gesture.centroid("releases","position") - raw_gesture.centroid("presses","position")).length()
-				if raw_gesture.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT and\
-					 raw_gesture.is_consistent(TAP_DISTANCE_LIMIT, FINGER_SIZE*fingers) and\
-					 _released_together(raw_gesture, MULTI_FINGER_RELEASE_THRESHOLD):
-					_emit("multi_tap", InputEventMultiScreenTap.new(raw_gesture))
-				if raw_gesture.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD and\
-					 raw_gesture.is_consistent(FINGER_SIZE, FINGER_SIZE*fingers) and\
-					 _released_together(raw_gesture, MULTI_FINGER_RELEASE_THRESHOLD):
-					_emit("multi_swipe", InputEventMultiScreenSwipe.new(raw_gesture))
+				var distance : float = (raw_gesture_data.centroid("releases","position") - raw_gesture_data.centroid("presses","position")).length()
+				if raw_gesture_data.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT and\
+					 raw_gesture_data.is_consistent(TAP_DISTANCE_LIMIT, FINGER_SIZE*fingers) and\
+					 _released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
+					_emit("multi_tap", InputEventMultiScreenTap.new(raw_gesture_data))
+				if raw_gesture_data.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD and\
+					 raw_gesture_data.is_consistent(FINGER_SIZE, FINGER_SIZE*fingers) and\
+					 _released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
+					_emit("multi_swipe", InputEventMultiScreenSwipe.new(raw_gesture_data))
 			_end_gesture()
 		_cancel_single_drag()
 
 func _handle_screen_drag(event : InputEventScreenDrag) -> void:
-	raw_gesture._update_screen_drag(event)
-	_emit("raw_gesture", raw_gesture)
-	if raw_gesture.drags.size() > 1:
+	raw_gesture_data._update_screen_drag(event)
+	_emit("raw_gesture", raw_gesture_data)
+	if raw_gesture_data.drags.size() > 1:
 		_cancel_single_drag()
-		var gesture : int = _identify_gesture(raw_gesture)
+		var gesture : int = _identify_gesture(raw_gesture_data)
 		if gesture == Gesture.PINCH:
-			_emit("pinch", InputEventScreenPinch.new(raw_gesture, event))
+			_emit("pinch", InputEventScreenPinch.new(raw_gesture_data, event))
 		elif gesture == Gesture.MULTI_DRAG:
-			_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture, event))
+			_emit("multi_drag", InputEventMultiScreenDrag.new(raw_gesture_data, event))
 		elif gesture == Gesture.TWIST:
-			_emit("twist",InputEventScreenTwist.new(raw_gesture, event))
+			_emit("twist",InputEventScreenTwist.new(raw_gesture_data, event))
 	else:
 		if _single_drag_enabled:
-			_emit("single_drag", InputEventSingleScreenDrag.new(raw_gesture))
+			_emit("single_drag", InputEventSingleScreenDrag.new(raw_gesture_data))
 		else:
 			if _drag_startup_timer.is_stopped(): _drag_startup_timer.start(DRAG_STARTUP_TIME)
 
@@ -283,16 +283,16 @@ func _cancel_single_drag() -> void:
 	_single_drag_enabled = false
 	_drag_startup_timer.stop()
 
-func _released_together(_raw_gesture : RawGesture, threshold : float) -> bool:
-	_raw_gesture = _raw_gesture.rollback_relative(threshold)[0]
-	return _raw_gesture.size() == _raw_gesture.active_touches
+func _released_together(_raw_gesture_data : RawGesture, threshold : float) -> bool:
+	_raw_gesture_data = _raw_gesture_data.rollback_relative(threshold)[0]
+	return _raw_gesture_data.size() == _raw_gesture_data.active_touches
 
 # Checks if the gesture is pinch
-func _identify_gesture(_raw_gesture : RawGesture) -> int:
-	var center : Vector2 = _raw_gesture.centroid("drags","position")
+func _identify_gesture(_raw_gesture_data : RawGesture) -> int:
+	var center : Vector2 = _raw_gesture_data.centroid("drags","position")
 	
 	var sector : int = -1
-	for e in _raw_gesture.drags.values():
+	for e in _raw_gesture_data.drags.values():
 		var adjusted_position : Vector2 = center - e.position
 		var raw_angle      : float = fmod(adjusted_position.angle_to(e.relative) + (PI/4), TAU) 
 		var adjusted_angle : float = raw_angle if raw_angle >= 0 else raw_angle + TAU
@@ -308,25 +308,25 @@ func _identify_gesture(_raw_gesture : RawGesture) -> int:
 		return Gesture.TWIST
 
 func _on_drag_startup_timer_timeout() -> void:
-	_single_drag_enabled = raw_gesture.drags.size() == 1
+	_single_drag_enabled = raw_gesture_data.drags.size() == 1
 
 func _on_long_press_timer_timeout() -> void:
-	var ends_centroid   : Vector2    = Util.centroid(raw_gesture.get_ends().values())
-	var starts_centroid : Vector2    = raw_gesture.centroid("presses", "position")
+	var ends_centroid   : Vector2    = Util.centroid(raw_gesture_data.get_ends().values())
+	var starts_centroid : Vector2    = raw_gesture_data.centroid("presses", "position")
 	var distance        : float      = (ends_centroid - starts_centroid).length()
 
-	if raw_gesture.releases.empty() and distance <= LONG_PRESS_DISTANCE_LIMIT and\
-		 raw_gesture.is_consistent(LONG_PRESS_DISTANCE_LIMIT, FINGER_SIZE*raw_gesture.size()):
+	if raw_gesture_data.releases.empty() and distance <= LONG_PRESS_DISTANCE_LIMIT and\
+		 raw_gesture_data.is_consistent(LONG_PRESS_DISTANCE_LIMIT, FINGER_SIZE*raw_gesture_data.size()):
 		if _single_touch_cancelled:
-			_emit("multi_long_press", InputEventMultiScreenLongPress.new(raw_gesture))
+			_emit("multi_long_press", InputEventMultiScreenLongPress.new(raw_gesture_data))
 		else:
-			_emit("single_long_press", InputEventSingleScreenLongPress.new(raw_gesture))
+			_emit("single_long_press", InputEventSingleScreenLongPress.new(raw_gesture_data))
 	
 
 func _end_gesture() -> void:
 	_single_drag_enabled = false
 	_long_press_timer.stop()
-	raw_gesture = RawGesture.new()
+	raw_gesture_data = RawGesture.new()
 
 # create a native touch event
 func _native_touch_event(index : int, position : Vector2, pressed : bool) -> InputEventScreenTouch:
@@ -337,12 +337,12 @@ func _native_touch_event(index : int, position : Vector2, pressed : bool) -> Inp
 	return native_touch
 
 # create a native touch event
-func _native_drag_event(index : int, position : Vector2, relative : Vector2, speed : Vector2) -> InputEventScreenDrag:
+func _native_drag_event(index : int, position : Vector2, relative : Vector2, velocity : Vector2) -> InputEventScreenDrag:
 	var native_drag : InputEventScreenDrag = InputEventScreenDrag.new()
 	native_drag.index = index
 	native_drag.position = position
 	native_drag.relative  = relative 
-	native_drag.speed    = speed
+	native_drag.velocity    = velocity
 	return native_drag
 
 func _native_mouse_button_event(button : int) -> InputEventMouseButton:
@@ -364,5 +364,5 @@ func _set_default_action(action : String, event : InputEvent) -> void:
 func _add_timer(timer : Timer, func_name : String) -> void:
 	timer.one_shot = true
 	if func_name:
-		timer.connect("timeout", self, func_name)
+		timer.connect("timeout", Callable(self, func_name))
 	self.add_child(timer)

--- a/RawGesture.gd
+++ b/RawGesture.gd
@@ -16,15 +16,15 @@ const Util : GDScript = preload("Util.gd")
 class Event:
 	var time  : float = -1 # (secs)
 	var index : int   = -1
-	func as_text() -> String:
+	func as_string() -> String:
 		return "ind: " + str(index) + " | time: " + str(time)
 
 class Touch:
 	extends Event
 	var position : Vector2 = Vector2.ZERO
 	var pressed  : bool 
-	func as_text() -> String:
-		return super.as_text() + " | pos: " + str(position) + " | pressed: " + str(pressed)
+	func as_string() -> String:
+		return super.as_string() + " | pos: " + str(position) + " | pressed: " + str(pressed)
 
 
 class Drag:
@@ -33,8 +33,8 @@ class Drag:
 	var relative  : Vector2 = Vector2.ZERO
 	var velocity     : Vector2 = Vector2.ZERO
 
-	func as_text() -> String:
-		return super.as_text() + " | pos: " + str(position) + " | relative: " + str(relative)
+	func as_string() -> String:
+		return super.as_string() + " | pos: " + str(position) + " | relative: " + str(relative)
 
 
 #############
@@ -182,16 +182,16 @@ func latest_event_id(latest_time : float = -1) -> Array:
 				latest_time = event_time
 	return res
 
-func as_text() -> String:
+func as_string() -> String:
 	var txt = "presses: "
 	for e in presses.values():
-		txt += "\n" + e.as_text()
+		txt += "\n" + e.as_string()
 	txt += "\ndrags: "
 	for e in drags.values():
-		txt += "\n" + e.as_text()
+		txt += "\n" + e.as_string()
 	txt += "\nreleases: "
 	for e in releases.values():
-		txt += "\n" + e.as_text()
+		txt += "\n" + e.as_string()
 	return txt
 
 func _update_screen_drag(event : InputEventScreenDrag, time : float = -1) -> void:

--- a/RawGesture.gd
+++ b/RawGesture.gd
@@ -7,7 +7,7 @@ class_name RawGesture
 # Const #
 #########
 
-const Util : Object = preload("Util.gd")
+const Util : GDScript = preload("Util.gd")
 
 ###########
 # Classes #
@@ -31,7 +31,7 @@ class Drag:
 	extends Event
 	var position  : Vector2 = Vector2.ZERO
 	var relative  : Vector2 = Vector2.ZERO
-	var speed     : Vector2 = Vector2.ZERO
+	var velocity     : Vector2 = Vector2.ZERO
 
 	func as_text() -> String:
 		return .as_text() + " | pos: " + str(position) + " | relative: " + str(relative)
@@ -197,7 +197,7 @@ func _update_screen_drag(event : InputEventScreenDrag, time : float = -1) -> voi
 	var drag : Drag = Drag.new()
 	drag.position  = event.position
 	drag.relative  = event.relative
-	drag.speed     = event.speed
+	drag.velocity  = event.velocity
 	drag.index     = event.index 
 	drag.time      = time
 	_add_history(event.index, "drags", drag)

--- a/RawGesture.gd
+++ b/RawGesture.gd
@@ -24,7 +24,7 @@ class Touch:
 	var position : Vector2 = Vector2.ZERO
 	var pressed  : bool 
 	func as_text() -> String:
-		return .as_text() + " | pos: " + str(position) + " | pressed: " + str(pressed)
+		return super.as_text() + " | pos: " + str(position) + " | pressed: " + str(pressed)
 
 
 class Drag:
@@ -34,7 +34,7 @@ class Drag:
 	var velocity     : Vector2 = Vector2.ZERO
 
 	func as_text() -> String:
-		return .as_text() + " | pos: " + str(position) + " | relative: " + str(relative)
+		return super.as_text() + " | pos: " + str(position) + " | relative: " + str(relative)
 
 
 #############
@@ -108,7 +108,7 @@ func rollback_absolute(time : float) -> Array:
 	var rg : RawGesture = copy()
 
 	var latest_event_id : Array = rg.latest_event_id(time)
-	while !latest_event_id.empty():
+	while !latest_event_id.is_empty():
 		var latest_index  : int    = latest_event_id[0]
 		var latest_type   : String = latest_event_id[1]
 		var latest_event = rg.history[latest_index][latest_type].pop_back()
@@ -117,9 +117,9 @@ func rollback_absolute(time : float) -> Array:
 			rg.active_touches -= 1
 		elif latest_type == "releases":
 			rg.active_touches += 1
-		if rg.history[latest_index][latest_type].empty():
+		if rg.history[latest_index][latest_type].is_empty():
 			rg.history[latest_index].erase(latest_type)
-			if rg.history[latest_index].empty():
+			if rg.history[latest_index].is_empty():
 				rg.history.erase(latest_index)
 		latest_event_id = rg.latest_event_id(time)
 

--- a/Util.gd
+++ b/Util.gd
@@ -14,4 +14,4 @@ static func centroid(es : Array):
 	return sum / es.size()
 
 static func now() -> float:
-	return float(OS.get_ticks_usec())/SEC_IN_USEC
+	return float(Time.get_ticks_usec())/SEC_IN_USEC


### PR DESCRIPTION
Resolves https://github.com/Federico-Ciuffardi/GodotTouchInputManager/issues/22.

This is branched off of @dave2's fork and includes additional fixes to make the library work with Godot 4. I've tested this version with the "Demo" project as well as the "GestureControlledCamera2D"

* https://github.com/Federico-Ciuffardi/GodotTouchInputManager-Demo/pull/4
* https://github.com/Federico-Ciuffardi/GestureControlledCamera2D/pull/7

**One remaining issue is that by default, users will get the following compiler error in Godot 4**:

```
W 0:00:06:0315   The method "as_text" overrides a method from native class "InputEvent". This won't be called by the engine and may not work as expected.
  <GDScript Error>NATIVE_METHOD_OVERRIDE
  <GDScript Source>InputEventScreenTwist.gd:18
```

This is because in Godot 4 the maintainers have decided to treat the case where you are overriding a native method through GDScript as an error due to it being ambiguous: https://github.com/godotengine/godot/issues/55024. In order to compile it, you'll need to go into Project Settings, toggle "Advanced Settings", find Debug > GDScript, and set "Native Method Override" to warn instead of error. The full path to this option is:

```
debug/gdscript/warnings/native_method_override
```

The other big problem is that the Godot 4 version of this library is not compatible with Godot 3. Easiest thing for now would be to keep it on a branch and have a big bold statement in the README directing people to this branch. Or alternatively just have them in separate folders?  