### PR TITLE
add "positions" for InputEventMultiScreenTap

### DIFF
--- a/CustomInputEvents/InputEventMultiScreenTap.gd
+++ b/CustomInputEvents/InputEventMultiScreenTap.gd
@@ -2,6 +2,7 @@ class_name InputEventMultiScreenTap
 extends InputEventAction
 
 var position   : Vector2
+var positions  : Array
 var fingers    : int
 var raw_gesture : RawGesture
 
@@ -10,6 +11,7 @@ func _init(_raw_gesture : RawGesture = null) -> void:
 	if raw_gesture: 
 		fingers = raw_gesture.size()
 		position = raw_gesture.centroid("presses", "position")
+		positions = raw_gesture.get_property_array("presses", "position")
 
 func as_string() -> String:
 	return "position=" + str(position) + "|fingers=" + str(fingers)

--- a/RawGesture.gd
+++ b/RawGesture.gd
@@ -58,9 +58,13 @@ var elapsed_time   : float = -1 # (secs)
 func size() -> int:
 	return presses.size()
 
-func centroid(events_name : String , property_name : String):
+func get_property_array(events_name : String , property_name : String):
 	var arr : Array = get(events_name).values()
 	arr = Util.map_callv(arr , "get", [property_name])
+	return arr
+
+func centroid(events_name : String , property_name : String):
+	var arr : Array = get_property_array(events_name, property_name)
 	return Util.centroid(arr)
 
 func get_ends() -> Dictionary:


### PR DESCRIPTION
related to #32 

This does not add the `any_tap` signal just a `positions` array for `InputEventMultiScreenTap` which include the position of all individual taps.

To do this I made use of the `centroid` method, splitting it to make a new `get_property_array` method (feel free to rename)
