### PR TITLE
Revert "Add "any_tap" signal"

### DIFF
--- a/InputManager.gd
+++ b/InputManager.gd
@@ -65,7 +65,6 @@ signal twist
 signal raw_gesture
 signal cancel
 signal any_gesture
-signal any_tap
 
 ########
 # Enum #
@@ -187,7 +186,6 @@ func _handle_screen_touch(event : InputEventScreenTouch) -> void:
 				var distance : float = (raw_gesture_data.releases[0].position - raw_gesture_data.presses[0].position).length()
 				if raw_gesture_data.elapsed_time < TAP_TIME_LIMIT and distance <= TAP_DISTANCE_LIMIT:
 					_emit("single_tap", InputEventSingleScreenTap.new(raw_gesture_data))
-					_emit("any_tap", InputEventMultiScreenTap.new(raw_gesture_data))
 				if raw_gesture_data.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD:
 					_emit("single_swipe", InputEventSingleScreenSwipe.new(raw_gesture_data))
 		if raw_gesture_data.active_touches == 0: # last finger released
@@ -197,7 +195,6 @@ func _handle_screen_touch(event : InputEventScreenTouch) -> void:
 					raw_gesture_data.is_consistent(TAP_DISTANCE_LIMIT, FINGER_SIZE*fingers) and\
 					_released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):
 					_emit("multi_tap", InputEventMultiScreenTap.new(raw_gesture_data))
-					_emit("any_tap", InputEventMultiScreenTap.new(raw_gesture_data))
 				if raw_gesture_data.elapsed_time < SWIPE_TIME_LIMIT and distance > SWIPE_DISTANCE_THRESHOLD and\
 					raw_gesture_data.is_consistent(FINGER_SIZE, FINGER_SIZE*fingers) and\
 					_released_together(raw_gesture_data, MULTI_FINGER_RELEASE_THRESHOLD):


### PR DESCRIPTION
Reverts Federico-Ciuffardi/GodotTouchInputManager#34

@rehhouari sorry but I just realized that this causes repeated events to be emitted to `_input` and also to the `any_gesture` signal.

Maybe you could try using `emit_signal` directly instead of `_emit`.

Although in my opinion it would be better to let GDTIM users handle this like this:
```
if event is InputEventSingleScreenTap:
#...
elif event is InputEventMultiScreenTap:
#...
```
and avoid making GDTIM more complex. Since otherwise we would be making a special case only for signals and taps. 

If differentiating between single and multi custom input events is not really useful in general, I would prefer to evaluate merging them all, for example `InputEventSingleScreenTap` and `InputEventMultiScreenTap` into `InputEventScreenTap`, and let users decide to filter the `InputEventScreenTap` events with more than one finger if they would like to something similar to `InputEventSingleScreenTap`.

Let me know what you think.